### PR TITLE
[Finish]admin側注文機能

### DIFF
--- a/app/assets/javascripts/admin/order_commodities.coffee
+++ b/app/assets/javascripts/admin/order_commodities.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/admin/order_commodities.scss
+++ b/app/assets/stylesheets/admin/order_commodities.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the admin/order_commodities controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/admin/order_commodities_controller.rb
+++ b/app/controllers/admin/order_commodities_controller.rb
@@ -1,0 +1,23 @@
+class Admin::OrderCommoditiesController < ApplicationController
+  before_action :authenticate_admin!
+
+  def update
+    @order_commodity = OrderCommodity.find(params[:id])
+    @order = @order_commodity.order
+    @order_commodity.update(order_commodity_params)
+
+    if @order_commodity.commodity_status == "制作中"
+      @order.update(order_status: 2)
+    elsif @order.order_commodities.count == @order.order_commodities.where(commodity_status: "製作完了").count
+      @order.update(order_status: 3)
+    end
+
+    @order_commodities = @order.order_commodities
+    redirect_to admin_order_path(@order.id)
+  end
+
+  private
+  def order_commodity_params
+    params.require(:order_commodity).permit(:commodity_status)
+  end
+end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,7 +1,35 @@
 class Admin::OrdersController < ApplicationController
+  before_action :authenticate_admin!
+
   def index
+    case params[:order_sort]
+    when "0"
+      @customer = Customer.find(params[:customer_id])
+      @orders = @customer.orders.page(params[:page]).per(8).reverse_order
+    else
+      @orders = Order.page(params[:page]).per(8).reverse_order
+    end
+
   end
 
   def show
+    @order = Order.find(params[:id])
+    @order_commodities = @order.order_commodities
+  end
+
+  def update
+    @order = Order.find(params[:id])
+    @order.update(order_params)
+    if @order.order_status == "入金確認"
+      @order_commodities = @order.order_commodities.update(commodity_status: 1)
+    end
+    redirect_to admin_order_path(@order.id)
+  end
+
+
+  private
+
+  def order_params
+    params.require(:order).permit(:order_status)
   end
 end

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -62,6 +62,9 @@ class Public::OrdersController < ApplicationController
   end
 
   def show
+    if params[:id] === "confirm"
+      return redirect_to  new_order_path
+    end
     @order = Order.find(params[:id])
   end
 
@@ -70,7 +73,7 @@ class Public::OrdersController < ApplicationController
   def order_params
     params.require(:order).permit(:destination_postal_code, :destination_address, :destination_name, :payment, :sub_total, :freight, :total_due)
   end
-  
+
   def new_address_params
     params.permit(:destination_postal_code, :destination_address, :destination_name)
   end

--- a/app/helpers/admin/order_commodities_helper.rb
+++ b/app/helpers/admin/order_commodities_helper.rb
@@ -1,0 +1,2 @@
+module Admin::OrderCommoditiesHelper
+end

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -46,7 +46,7 @@
         <tr>
           <td></td>
           <td><%= link_to "編集する", edit_admin_customer_path(@customer.id), class:"btn btn-lg btn-success mt-5" %></td>
-          <td><%= link_to "注文履歴一覧を見る", admin_root_path, class: "btn btn-lg btn-primary mt-5" %></td>
+          <td><%= link_to "注文履歴一覧を見る", admin_root_path(customer_id: @customer.id, order_sort: 0), class: "btn btn-lg btn-primary mt-5" %></td>
         </tr>
       </table>
     </div>

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -1,2 +1,32 @@
-<h1>Admin::Orders#index</h1>
-<p>Find me in app/views/admin/orders/index.html.erb</p>
+<div class="container">
+  <div class="row">
+    <di class="col">
+      <h3>注文履歴一覧</h3>
+      <table class="table table-bordered">
+        <tbody>
+          <tr class="table-info">
+            <td scope="col">購入日時</td>
+            <td scope="col">購入者</td>
+            <td scope="col">注文個数</td>
+            <td scope="col">注文ステータス</td>
+          </tr>
+          <% @orders.each do |order| %>
+          <tr>
+            <td scope="row">
+              <%= link_to admin_order_path(order.id) do %>
+                <%= order.created_at.strftime('%Y/%m/%d %H:%M') %>
+              <% end %>
+            </td>
+            <td><%= order.customer.name %></td>
+            <td><%= order.order_commodities.count %></td>
+            <td><%= order.order_status %></td>
+          </tr>
+          <% end %>
+        </tbody>
+      </table>
+      <%= paginate @orders %>
+    </div>
+  </div>
+</div>
+
+

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -1,2 +1,86 @@
-<h1>Admin::Orders#show</h1>
-<p>Find me in app/views/admin/orders/show.html.erb</p>
+<div class="container">
+  <div class="row">
+    <div class="col-10">
+      <h4>注文履歴詳細</h4>
+      <table class="table table-borderless">
+        <tbody>
+          <tr>
+            <td scope="row">購入者</td>
+            <td scope="col"><%= @order.customer.name %></td>
+          </tr>
+          <tr>
+            <td scope="row">注文日</td>
+            <td><%= @order.created_at.strftime('%Y/%m/%d') %></td>
+          </tr>
+          <tr>
+            <td scope="row">配送先</td>
+            <td>
+              <%= @order.order_destination_set %><br>
+              <%= @order.destination_name %>
+            </td>
+          </tr>
+          <tr>
+            <td scope="row">支払方法</td>
+            <td><%= @order.payment %></td>
+          </tr>
+          <tr>
+            <td scope="row">注文ステータス</td>
+            <td><%= @order.order_status %>
+              <%= form_with model: @order, url: admin_order_path, local:true do |f| %>
+                <%= f.select :order_status, options_for_select(Order.order_statuses.keys) %>
+                <%= f.submit "更新", class: "btn btn-sm btn-success" %>
+              <% end %>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-9">
+      <table class="table table-bordered">
+        <tbody>
+          <tr class="table-info">
+            <td scope="col">商品名</td>
+            <td scope="col">単価（税込）</td>
+            <td scope="col">数量</td>
+            <td scope="col">小計</td>
+            <td scope="col">製作ステータス</td>
+          </tr>
+          <% @order_commodities.each do |order_commodity| %>
+          <tr>
+            <td><%= order_commodity.commodity.name %></td>
+            <td><%= order_commodity.commodity.add_tax_sales_price.to_s(:delimited) %></td>
+            <td><%= order_commodity.quantity %></td>
+            <td><%= order_commodity.price.to_s(:delimited) %></td>
+            <td><%= order_commodity.commodity_status %>
+                <%= form_with model: order_commodity, url:admin_order_commodity_path(order_commodity.id) ,local:true do |f| %>
+                  <%= f.select :commodity_status, options_for_select(OrderCommodity.commodity_statuses.keys) %>
+                  <%= f.submit "更新", class: "btn btn-sm btn-success" %>
+                <% end %>
+            </td>
+          </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+    <div class="col-3">
+      <table class="table table-borderless">
+        <tbody>
+          <tr>
+            <td scope="row">商品合計</td>
+            <td scope="col"><%= @order.sub_total.to_s(:delimited) %>円</td>
+          </tr>
+          <tr>
+            <td scope="row">送料</td>
+            <td><%= @order.freight.to_s(:delimited) %>円</td>
+          </tr>
+          <tr>
+            <td scope="row">請求額合計</td>
+            <td><%= @order.total_due.to_s(:delimited) %>円</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -54,6 +54,7 @@
           </ul>
         </div>
       </div>
+    </div>
       <%= f.submit "確認画面へ進む", class: "btn btn-primary" %>
     <% end %>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   namespace :admin do
     root to: 'orders#index'
     resources :orders, only: [:show, :update]
+    resources :order_commodities, only: [:update]
     resources :genres, only: [:create, :index, :edit, :update]
     resources :commodities, except: [:destroy]
     resources :customers, only: [:index, :show, :edit, :update]

--- a/test/controllers/admin/order_commodities_controller_test.rb
+++ b/test/controllers/admin/order_commodities_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Admin::OrderCommoditiesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 管理者側の注文機能完成（他public側機能のバグ修正）
抜け漏れあったらごめんなさい〜〜！

### 内容
##### 管理者側
- 注文一覧画面の表示に関して、遷移元がshowページの場合その顧客が持つ注文履歴のみが表示されます。（そのためshowのリンクにパラメータを渡しています）
- 管理者側で注文履歴を確認、各ステータスを変更できるようになりました。
##### 顧客側
- 注文情報入力画面のフッターが一部消えていたバグを修正（閉じタグ忘れ）
- 注文内容確認(confirm)画面でリロード→エラー画面が出たものを修正して、注文情報入力(new)画面に遷移するようにしました。

### できていないところ

- 各ステータス更新時、プルダウンメニューの値保持をして現在のステータス表記をすること。

### 注意

- ルーティング追加しています。(order_commoditiesコントローラにupdateアクションのみresourcesで設定)